### PR TITLE
Fix loading times in server addition and sync dir addition windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for translations.
 
+### Fixed
+- Fixed loading times when adding remotes with high storage usage.
+
 ## [0.4.6] - 2023-02-24
 ### Fixed
 - Fixed HTML elements in metainfo release descriptions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.0] - 2023-03-27
 ### Added
 - Added support for translations.
 
+### Changed
+- Fixed loading times when adding new sync directories.
+- Made autocompletions in sync directory additions more dynamic.
+
 ### Fixed
 - Fixed loading times when adding remotes with high storage usage.
+- Fixed freeze when ports needed by `rclone authorize` are already being used.
 
 ## [0.4.6] - 2023-02-24
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "celeste"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "base64 0.20.0",
  "blocking",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "celeste-tray"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "gtk",
  "hw-msg",
@@ -2363,7 +2363,7 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libceleste"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "blocking",
  "futures",

--- a/assets/com.hunterwittenborn.Celeste.metainfo.xml
+++ b/assets/com.hunterwittenborn.Celeste.metainfo.xml
@@ -41,6 +41,44 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release date="2023-03-27" version="0.5.0">
+            <description>
+                <p>
+                    Feature additions in this release:
+                </p>
+                <ul>
+                    <li>
+                        Added support for translations.
+                    </li>
+                </ul>
+                <p>
+                    Changes made in this release:
+                </p>
+                <ul>
+                    <li>
+                        Fixed loading times when adding new sync directories.
+                    </li>
+                    <li>
+                        Made autocompletions in sync directory additions more dynamic.
+                    </li>
+                </ul>
+                <p>
+                    Fixes in this release:
+                </p>
+                <ul>
+                    <li>
+                        Fixed loading times when adding remotes with high storage usage.
+                    </li>
+                    <li>
+                        Fixed freeze when ports needed by
+                        <code>
+                            rclone authorize
+                        </code>
+                        are already being used.
+                    </li>
+                </ul>
+            </description>
+        </release>
         <release date="2023-02-24" version="0.4.6">
             <description>
                 <p>

--- a/celeste-tray/Cargo.toml
+++ b/celeste-tray/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celeste-tray"
-version = "0.4.6"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/celeste/Cargo.toml
+++ b/celeste/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "celeste"
-version = "0.4.6"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/celeste/src/login/mod.rs
+++ b/celeste/src/login/mod.rs
@@ -105,30 +105,12 @@ pub fn login(app: &Application, db: &DatabaseConnection) -> Option<RemotesModel>
     }));
 
     // The stack containing the forms for all login sections.
-    let dropbox_name = ServerType::Dropbox(dropbox::DropboxConfig {
-        ..Default::default()
-    })
-    .to_string();
-    let gdrive_name = ServerType::GDrive(gdrive::GDriveConfig {
-        ..Default::default()
-    })
-    .to_string();
-    let nextcloud_name = ServerType::Nextcloud(nextcloud::NextcloudConfig {
-        ..Default::default()
-    })
-    .to_string();
-    let owncloud_name = ServerType::Owncloud(owncloud::OwncloudConfig {
-        ..Default::default()
-    })
-    .to_string();
-    let pcloud_name = ServerType::PCloud(pcloud::PCloudConfig {
-        ..Default::default()
-    })
-    .to_string();
-    let webdav_name = ServerType::WebDav(webdav::WebDavConfig {
-        ..Default::default()
-    })
-    .to_string();
+    let dropbox_name = ServerType::Dropbox(Default::default()).to_string();
+    let gdrive_name = ServerType::GDrive(Default::default()).to_string();
+    let nextcloud_name = ServerType::Nextcloud(Default::default()).to_string();
+    let owncloud_name = ServerType::Owncloud(Default::default()).to_string();
+    let pcloud_name = ServerType::PCloud(Default::default()).to_string();
+    let webdav_name = ServerType::WebDav(Default::default()).to_string();
 
     // The dropdown for selecting the server type.
     let server_type_dropdown = ComboRow::builder().title(&tr::tr!("Server Type")).build();

--- a/celeste/src/login/mod.rs
+++ b/celeste/src/login/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     entities::{RemotesActiveModel, RemotesModel},
     gtk_util,
     mpsc::{self, Sender},
-    rclone::{self},
+    rclone,
 };
 use libceleste::traits::prelude::*;
 mod dropbox;
@@ -66,17 +66,7 @@ impl ToString for ServerType {
 
 // Verify if a specific config can log in to a server.
 pub fn can_login(_app: &Application, config_name: &str) -> bool {
-    let res = librclone::rpc(
-        "operations/size",
-        json!({
-            "fs": format!("{config_name}:"),
-            "remote": "/"
-        })
-        .to_string(),
-    );
-
-    if let Err(err_str) = res {
-        let err: rclone::RcloneError = serde_json::from_str(&err_str).unwrap();
+    if let Err(err) = rclone::sync::stat(config_name, "/") {
         let err_msg = if err.error.contains("Temporary failure in name resolution") {
             tr::tr!(
                 "Unable to connect to the server. Check your internet connection and try again."

--- a/celeste/src/rclone.rs
+++ b/celeste/src/rclone.rs
@@ -208,8 +208,9 @@ pub enum RcloneListFilter {
 }
 
 /// Functions for syncing to a remote.
-/// All of these functions run long-running tasks under
-/// [`libceleste::run_in_background`], so it's safe to run these under the GUI.
+/// All functions in this module automatically run under
+/// [`libceleste::run_in_background`], so they don't need to be wrapped around
+/// such to be ran during UI execution.
 pub mod sync {
     use super::{RcloneError, RcloneList, RcloneListFilter, RcloneRemoteItem, RcloneStat};
     use serde_json::json;

--- a/libceleste/Cargo.toml
+++ b/libceleste/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libceleste"
-version = "0.4.6"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/makedeb/PKGBUILD
+++ b/makedeb/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=celeste
-pkgver=0.4.6
+pkgver=0.5.0
 pkgrel=1
 pkgdesc='Sync your cloud files'
 arch=('any')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: celeste
 base: core22
-version: '0.4.6'
+version: '0.5.0'
 summary: Sync your cloud files
 description: |
   Celeste is a GUI file synchronization client that can connect to almost any cloud provider you'd like. It provides a streamlined experience to back up your files, and integrates directly into your desktop system.


### PR DESCRIPTION
Previously we scanned the entire remote for the list of folders before showing the window to add a new sync directory (the folder listings are used for autocompletions). This proved to be quite a long-running task when the remote contains a bunch of folders though - now we just check the list of folders for the currently entered path.

A somewhat-similar issue was also present when adding new sync remotes: It was of my knowledge that we only did a simple listing of the remote's root to see if we could connect fine, but it appears that we scanned and downloaded every file instead (using rclone's `operations/size` RC command). This has been changed to rclone's `operations/stat` RC command instead), which is immensely less expensive to run.