### PR TITLE
Add docker (dev)container + VSCode config with debugging support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm
+
+ARG deps="\
+    libgtk-4-dev \
+    libdbus-1-dev \
+    pkg-config \
+    libadwaita-1-dev \
+    golang \
+    libclang-dev \
+    "
+RUN apt-get update \
+    && apt-get install -y ${deps} \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Rust-Celeste",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "../"
+	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"streetsidesoftware.code-spell-checker"
+			]
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+	"runArgs": [
+		//Allow access to the internet
+		"--net",
+		"host",
+		// Share X server of host
+		"-e",
+		"DISPLAY=${localEnv:DISPLAY}",
+		"-e",
+		"XAUTHORITY=/tmp/.Xauthority",
+		"-v",
+		"${localEnv:HOME}/.Xauthority:/tmp/.Xauthority"
+	],
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,49 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'celeste'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=celeste",
+                    "--package=celeste"
+                ],
+                "filter": {
+                    "name": "celeste",
+                    "kind": "bin"
+                }
+            },
+            "initCommands": [
+                // Disable SIGURG handling
+                "pro hand -p true -s false SIGURG"
+            ],
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'celeste'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=celeste",
+                    "--package=celeste"
+                ],
+                "filter": {
+                    "name": "celeste",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}


### PR DESCRIPTION
To (hopefully) ease the process on starting contributing to Celeste I have made a devcontainer config and docker file.

This allows Celeste building and debugging from a docker container.
Not having to install the rust development environment and project development packages on your local machine.

Note that I do not have any rust experience so I've build on examples I found online.